### PR TITLE
Use full DIM loadout links instead of deprecated Optimizer links

### DIFF
--- a/frontend/public/package-lock.json
+++ b/frontend/public/package-lock.json
@@ -8,6 +8,7 @@
       "name": "public",
       "version": "0.1.0",
       "dependencies": {
+        "@destinyitemmanager/dim-api-types": "^1.26.0",
         "@fortawesome/fontawesome-svg-core": "^6.1.1",
         "@fortawesome/free-brands-svg-icons": "^6.1.1",
         "@fortawesome/free-regular-svg-icons": "^6.1.1",
@@ -2392,6 +2393,11 @@
         "postcss": "^8.2",
         "postcss-selector-parser": "^6.0.10"
       }
+    },
+    "node_modules/@destinyitemmanager/dim-api-types": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@destinyitemmanager/dim-api-types/-/dim-api-types-1.26.0.tgz",
+      "integrity": "sha512-eMj112Sz+7Z+rYwHbLfAyQ7K2Nkizv7DsUtdLaWN60B5U0OlB/CHTaLYlQdXOUXkPj0N/L0hfio0aXWBlCB9sA=="
     },
     "node_modules/@emotion/is-prop-valid": {
       "version": "1.2.0",
@@ -17314,6 +17320,11 @@
       "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-2.0.2.tgz",
       "integrity": "sha512-IkpVW/ehM1hWKln4fCA3NzJU8KwD+kIOvPZA4cqxoJHtE21CCzjyp+Kxbu0i5I4tBNOlXPL9mjwnWlL0VEG4Fg==",
       "requires": {}
+    },
+    "@destinyitemmanager/dim-api-types": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@destinyitemmanager/dim-api-types/-/dim-api-types-1.26.0.tgz",
+      "integrity": "sha512-eMj112Sz+7Z+rYwHbLfAyQ7K2Nkizv7DsUtdLaWN60B5U0OlB/CHTaLYlQdXOUXkPj0N/L0hfio0aXWBlCB9sA=="
     },
     "@emotion/is-prop-valid": {
       "version": "1.2.0",

--- a/frontend/public/package.json
+++ b/frontend/public/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@destinyitemmanager/dim-api-types": "^1.26.0",
     "@fortawesome/fontawesome-svg-core": "^6.1.1",
     "@fortawesome/free-brands-svg-icons": "^6.1.1",
     "@fortawesome/free-regular-svg-icons": "^6.1.1",
@@ -53,9 +54,6 @@
     ]
   },
   "devDependencies": {
-    "@types/react-helmet": "^6.1.5",
-    "@types/styled-components": "^5.1.25",
-    "tailwindcss": "^3.2.7",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^13.3.0",
     "@testing-library/user-event": "^13.5.0",
@@ -63,6 +61,9 @@
     "@types/node": "^16.11.39",
     "@types/react": "^18.0.12",
     "@types/react-dom": "^18.0.5",
+    "@types/react-helmet": "^6.1.5",
+    "@types/styled-components": "^5.1.25",
+    "tailwindcss": "^3.2.7",
     "typescript": "^4.7.3"
   }
 }

--- a/frontend/public/src/models/Build.ts
+++ b/frontend/public/src/models/Build.ts
@@ -1,17 +1,9 @@
+import { Loadout, LoadoutItem } from "@destinyitemmanager/dim-api-types"
 import { BungieApiService, Enums, Item, ManifestService, Socket, SocketItem } from "../data-utils/Main"
 import { DamageTypeEnum, ItemTypeEnum } from "../data-utils/models/Enums"
 // @ts-ignore
 import buildUtils from "../utils/buildUtils"
 import BuildSummary from "./BuildSummary"
-
-type DIMModsByBucket = {
-  [bucket: string]: Array<number>
-}
-
-type DIMLoadoutModel = {
-  mods?: Array<number>
-  modsByBucket?: DIMModsByBucket
-}
 
 class Build {
   primaryActivity?: string
@@ -29,66 +21,65 @@ class Build {
 
 
   toDIMLink(): string {
-    let url = `https://app.destinyitemmanager.com/optimizer?class=${this.class}&p=`
-    let loadout: DIMLoadoutModel = {
-      mods: []
+    let url = `https://app.destinyitemmanager.com/loadouts?loadout=`
+    const loadout: Loadout = {
+      id: "guardianforge", // DIM will replace this with unique ID upon receiving
+      name: this.name ?? "GuardianForge Loadout",
+      classType: this.class,
+      clearSpace: false,
+      equipped: [],
+      unequipped: [],
+      parameters: {
+        mods: [],
+        modsByBucket: {}
+      }
     }
-    if(this.items && this.items.kinetic && this.items.kinetic.mods) {
-      this.items.kinetic.mods.forEach(m => {
-        if(m.plugHash && m.name !== "Empty Mod Socket") {
-          loadout.mods?.push(Number(m.plugHash))
+    const toLoadoutItem = (item: BuildItem): LoadoutItem | undefined => item?.itemHash !== undefined ? ({hash: item.itemHash, id: item.itemInstanceId}) : undefined
+    if (this.items) {
+      // Armor mods are in a flat list for DIM to assign best
+      const armor = [this.items.helmet, this.items.arms, this.items.chest, this.items.legs, this.items.classItem]
+      armor.forEach(item => {
+        if (item) {
+          const mappedItem = toLoadoutItem(item)
+          if (mappedItem) {
+            loadout.equipped.push(mappedItem)
+          }
+          item.mods?.forEach(m => {
+            if(m.plugHash && m.name !== "Empty Mod Socket") {
+              loadout.parameters!.mods!.push(Number(m.plugHash))
+            }
+          })
         }
       })
-    }
-    if(this.items && this.items.energy && this.items.energy.mods) {
-      this.items.energy.mods.forEach(m => {
-        if(m.plugHash && m.name !== "Empty Mod Socket") {
-          loadout.mods?.push(Number(m.plugHash))
+
+      // Weapon mods could potentially be part of the weapon item `socketOverrides` in the future,
+      // but DIM doesn't support this right now.
+      const weapons = [this.items.kinetic, this.items.energy, this.items.power]
+      weapons.forEach(item => {
+        if (item) {
+          const mappedItem = toLoadoutItem(item)
+          if (mappedItem) {
+            loadout.equipped.push(mappedItem)
+          }
         }
       })
-    }
-    if(this.items && this.items.power && this.items.power.mods) {
-      this.items.power.mods.forEach(m => {
-        if(m.plugHash && m.name !== "Empty Mod Socket") {
-          loadout.mods?.push(Number(m.plugHash))
+
+      // Subclass configuration is part of the `socketOverrides`
+      if (this.items.subclass) {
+        const  subclassItem = toLoadoutItem(this.items.subclass)
+        if (subclassItem) {
+          subclassItem.socketOverrides = {}
+          const plugs = [this.items.subclass.abilities, this.items.subclass.aspects, this.items.subclass.fragments].flatMap(plugs => plugs ?? [])
+          plugs.forEach(p => {
+            if (p.socketIndex !== undefined && p.plugHash !== undefined && p.name !== "Empty Aspect Socket" && p.name !== "Empty Fragment Socket") {
+              subclassItem.socketOverrides![p.socketIndex] = Number(p.plugHash)
+            }
+          })
+          loadout.equipped.push(subclassItem)
         }
-      })
+      }
     }
-    if(this.items && this.items.helmet && this.items.helmet.mods) {
-      this.items.helmet.mods.forEach(m => {
-        if(m.plugHash && m.name !== "Empty Mod Socket") {
-          loadout.mods?.push(Number(m.plugHash))
-        }
-      })
-    }
-    if(this.items && this.items.arms && this.items.arms.mods) {
-      this.items.arms.mods.forEach(m => {
-        if(m.plugHash && m.name !== "Empty Mod Socket") {
-          loadout.mods?.push(Number(m.plugHash))
-        }
-      })
-    }
-    if(this.items && this.items.chest && this.items.chest.mods) {
-      this.items.chest.mods.forEach(m => {
-        if(m.plugHash && m.name !== "Empty Mod Socket") {
-          loadout.mods?.push(Number(m.plugHash))
-        }
-      })
-    }
-    if(this.items && this.items.legs && this.items.legs.mods) {
-      this.items.legs.mods.forEach(m => {
-        if(m.plugHash && m.name !== "Empty Mod Socket") {
-          loadout.mods?.push(Number(m.plugHash))
-        }
-      })
-    }
-    if(this.items && this.items.classItem && this.items.classItem.mods) {
-      this.items.classItem.mods.forEach(m => {
-        if(m.plugHash && m.name !== "Empty Mod Socket") {
-          loadout.mods?.push(Number(m.plugHash))
-        }
-      })
-    }
+
     url += encodeURIComponent(JSON.stringify(loadout))
     return url
   }

--- a/frontend/public/src/models/Build.ts
+++ b/frontend/public/src/models/Build.ts
@@ -34,10 +34,17 @@ class Build {
         modsByBucket: {}
       }
     }
-    const toLoadoutItem = (item: BuildItem): LoadoutItem | undefined => item?.itemHash !== undefined ? ({hash: item.itemHash, id: item.itemInstanceId}) : undefined
+    const toLoadoutItem = (item: BuildItem): LoadoutItem | undefined => 
+      item?.itemHash !== undefined ? ({hash: item.itemHash, id: item.itemInstanceId}) : undefined
     if (this.items) {
       // Armor mods are in a flat list for DIM to assign best
-      const armor = [this.items.helmet, this.items.arms, this.items.chest, this.items.legs, this.items.classItem]
+      const armor = [
+        this.items.helmet,
+        this.items.arms,
+        this.items.chest,
+        this.items.legs,
+        this.items.classItem
+      ]
       armor.forEach(item => {
         if (item) {
           const mappedItem = toLoadoutItem(item)
@@ -54,7 +61,11 @@ class Build {
 
       // Weapon mods could potentially be part of the weapon item `socketOverrides` in the future,
       // but DIM doesn't support this right now.
-      const weapons = [this.items.kinetic, this.items.energy, this.items.power]
+      const weapons = [
+        this.items.kinetic,
+        this.items.energy,
+        this.items.power
+      ]
       weapons.forEach(item => {
         if (item) {
           const mappedItem = toLoadoutItem(item)
@@ -66,12 +77,21 @@ class Build {
 
       // Subclass configuration is part of the `socketOverrides`
       if (this.items.subclass) {
-        const  subclassItem = toLoadoutItem(this.items.subclass)
+        const subclassItem = toLoadoutItem(this.items.subclass)
         if (subclassItem) {
           subclassItem.socketOverrides = {}
-          const plugs = [this.items.subclass.abilities, this.items.subclass.aspects, this.items.subclass.fragments].flatMap(plugs => plugs ?? [])
+          const plugs = [
+            this.items.subclass.abilities,
+            this.items.subclass.aspects,
+            this.items.subclass.fragments
+          ].flatMap(plugs => plugs ?? [])
           plugs.forEach(p => {
-            if (p.socketIndex !== undefined && p.plugHash !== undefined && p.name !== "Empty Aspect Socket" && p.name !== "Empty Fragment Socket") {
+            if (
+              p.socketIndex !== undefined &&
+              p.plugHash !== undefined && 
+              p.name !== "Empty Aspect Socket" && 
+              p.name !== "Empty Fragment Socket"
+            ) {
               subclassItem.socketOverrides![p.socketIndex] = Number(p.plugHash)
             }
           })


### PR DESCRIPTION
The old link format would open links in Optimizer, which only support `LoadoutParameters`. This PR sends the full Loadout structure to DIM's loadouts page, which properly supports items and subclass configuration.

<details><summary>Before</summary>

![grafik](https://github.com/GuardianForge/guardianforge.net/assets/14299449/365e0d78-fa62-4a36-a0af-e1cf97323121)

</details>

<details><summary>After</summary>

![grafik](https://github.com/GuardianForge/guardianforge.net/assets/14299449/9b78777c-2de2-4817-a8cd-d4f3bc6e1890)

</details>

cc @bhollis

